### PR TITLE
simplify docker build

### DIFF
--- a/integration-mapping-pipeline/env/Dockerfile
+++ b/integration-mapping-pipeline/env/Dockerfile
@@ -1,18 +1,13 @@
-FROM continuumio/miniconda3
+FROM condaforge/miniforge3
 
 RUN apt-get -y update && apt-get -y install gcc make libbz2-dev zlib1g-dev libncurses5-dev libncursesw5-dev liblzma-dev g++
 
 # DEBUG
 # RUN apt-get -y install vim less htop
 # DEBUG
+RUN mamba install -y -c conda-forge -c bioconda -c r python=3.12 snakemake samtools bowtie2 htslib emboss cd-hit bwa fastp fastqc r r-essentials
 
-RUN conda update -n base -c defaults conda
-
-RUN conda config --set use_only_tar_bz2 True
-
-RUN conda install -y -c conda-forge python=3.8 mamba && mamba install -y -c conda-forge -c bioconda -c r snakemake samtools bowtie2 htslib emboss cd-hit bwa fastp fastqc r r-essentials
-
-RUN mamba install -y -c conda-forge -c bioconda click pandas biopython pysam editdistance scipy networkx tqdm umi_tools pybedtools bioconductor-genomicranges bioconductor-genomicranges bioconductor-helloranges bioconductor-biostrings r-bedr r-ggseqlogo
+RUN mamba install -y -c conda-forge -c bioconda click pandas biopython pysam editdistance scipy networkx tqdm umi_tools pybedtools bioconductor-genomicranges bioconductor-helloranges bioconductor-biostrings r-bedr r-ggseqlogo
 
 RUN pip install git+https://github.com/hsulab-arc/MGEfinder-integration-mapping-pipeline.git
 


### PR DESCRIPTION
It looks like this is not the first time the Dockerfile has been updated, but I noticed with mamba now being part of conda it can be simplified. This switches to python 3.12 (python 3.8 is past EOL and caused problems for the conda install), points to condaforge instead of continuumio, and removes a duplicate mamba install for "bioconductor-genomicranges". The setting to use only tar bz2 doesn't seem to be needed anymore.